### PR TITLE
Add splash and onboarding flow to mobile app

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,15 +1,32 @@
 // App.js
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { SafeAreaView, StatusBar, AppState, LogBox } from 'react-native';
 import Home from './screens/Home';
+import SplashScreen from './screens/SplashScreen';
+import Onboarding from './screens/Onboarding';
 
 LogBox.ignoreLogs(['No callback found with cbID']); // dev-only
 
 export default function App() {
+  const [splash, setSplash] = useState(true);
+  const [onboarded, setOnboarded] = useState(false);
+
   useEffect(() => {
     const sub = AppState.addEventListener('change', () => {});
-    return () => sub.remove();
+    const timer = setTimeout(() => setSplash(false), 2000);
+    return () => {
+      sub.remove();
+      clearTimeout(timer);
+    };
   }, []);
+
+  if (splash) {
+    return <SplashScreen />;
+  }
+
+  if (!onboarded) {
+    return <Onboarding onDone={() => setOnboarded(true)} />;
+  }
 
   return (
     <SafeAreaView style={{ flex: 1 }}>

--- a/mobile/screens/Onboarding.tsx
+++ b/mobile/screens/Onboarding.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Switch } from 'react-native';
+
+interface Props {
+  onDone: () => void;
+}
+
+export default function Onboarding({ onDone }: Props) {
+  const [step, setStep] = useState(0);
+  const [location, setLocation] = useState(false);
+  const [notify, setNotify] = useState(false);
+
+  const next = () => setStep(s => s + 1);
+
+  if (step === 0) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.illustration}>🚗⛽</Text>
+        <Text style={styles.title}>Save money on every fill-up</Text>
+        <TouchableOpacity style={styles.button} onPress={next}>
+          <Text style={styles.buttonText}>Next</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (step === 1) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.flowRow}>
+          <Text style={styles.icon}>🔍</Text>
+          <Text style={styles.arrow}>→</Text>
+          <Text style={styles.icon}>⚖️</Text>
+          <Text style={styles.arrow}>→</Text>
+          <Text style={styles.icon}>💰</Text>
+        </View>
+        <Text style={styles.caption}>Search   Compare   Save</Text>
+        <TouchableOpacity style={styles.button} onPress={next}>
+          <Text style={styles.buttonText}>Next</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <View style={styles.row}>
+          <Text style={styles.label}>Location</Text>
+          <Switch value={location} onValueChange={setLocation} />
+        </View>
+        <View style={[styles.row, { marginTop: 10 }] }>
+          <Text style={styles.label}>Notifications</Text>
+          <Switch value={notify} onValueChange={setNotify} />
+        </View>
+      </View>
+      <TouchableOpacity style={[styles.button, { marginTop: 30 }]} onPress={onDone}>
+        <Text style={styles.buttonText}>Allow & Continue</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#008080',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  illustration: {
+    fontSize: 80,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#fff',
+    textAlign: 'center',
+    marginVertical: 20,
+  },
+  button: {
+    backgroundColor: '#fff',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#008080',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  flowRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  icon: {
+    fontSize: 48,
+  },
+  arrow: {
+    fontSize: 32,
+    marginHorizontal: 8,
+    color: '#fff',
+  },
+  caption: {
+    color: '#fff',
+    marginBottom: 20,
+  },
+  card: {
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 12,
+    width: '100%',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    fontSize: 16,
+    color: '#333',
+  },
+});

--- a/mobile/screens/SplashScreen.tsx
+++ b/mobile/screens/SplashScreen.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
+
+export default function SplashScreen() {
+  const dot1 = useRef(new Animated.Value(0)).current;
+  const dot2 = useRef(new Animated.Value(0)).current;
+  const dot3 = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const createAnim = (val: Animated.Value, delay: number) => {
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(delay),
+          Animated.timing(val, {
+            toValue: -10,
+            duration: 300,
+            useNativeDriver: true,
+          }),
+          Animated.timing(val, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: true,
+          }),
+          Animated.delay(300),
+        ])
+      ).start();
+    };
+
+    createAnim(dot1, 0);
+    createAnim(dot2, 150);
+    createAnim(dot3, 300);
+  }, [dot1, dot2, dot3]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.logo}>
+        <View style={styles.pinCircle}>
+          <Text style={styles.pump}>⛽</Text>
+        </View>
+        <View style={styles.pinTip} />
+      </View>
+      <Text style={styles.tagline}>Find the cheapest fuel near you</Text>
+      <View style={styles.dots}>
+        {[dot1, dot2, dot3].map((d, i) => (
+          <Animated.View key={i} style={{ transform: [{ translateY: d }] }}>
+            <Text style={styles.dot}>•</Text>
+          </Animated.View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#008080',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  logo: {
+    alignItems: 'center',
+  },
+  pinCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pinTip: {
+    width: 0,
+    height: 0,
+    borderLeftWidth: 15,
+    borderRightWidth: 15,
+    borderTopWidth: 20,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderTopColor: '#fff',
+  },
+  pump: {
+    fontSize: 40,
+    color: '#008080',
+  },
+  tagline: {
+    color: '#fff',
+    fontSize: 18,
+    marginTop: 20,
+  },
+  dots: {
+    flexDirection: 'row',
+    marginTop: 30,
+  },
+  dot: {
+    fontSize: 32,
+    color: '#fff',
+    marginHorizontal: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- Add teal splash screen with map-pin fuel logo, tagline and animated dots
- Introduce onboarding with welcome, how-it-works and permission steps
- Wire splash and onboarding flow into App entry

## Testing
- `npm test` *(fails: Missing script "test" in package.json)*
- `npx jest` *(fails: No tests found, exiting with code 1)*
- `npx tsc --noEmit` *(fails: Cannot find name 'describe' etc., missing @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b6deb547548328bcedb4d7dcfaa21c