### PR TITLE
Refresh stations when app resumes

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,5 +1,5 @@
 // App.js
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { SafeAreaView, StatusBar, AppState, LogBox } from 'react-native';
 import Home from './screens/Home';
 import SplashScreen from './screens/SplashScreen';
@@ -10,9 +10,15 @@ LogBox.ignoreLogs(['No callback found with cbID']); // dev-only
 export default function App() {
   const [splash, setSplash] = useState(true);
   const [onboarded, setOnboarded] = useState(false);
+  const homeRef = useRef(null);
 
   useEffect(() => {
-    const sub = AppState.addEventListener('change', () => {});
+    const handleChange = (nextState) => {
+      if (nextState === 'active') {
+        homeRef.current?.onAppStateChange?.(nextState);
+      }
+    };
+    const sub = AppState.addEventListener('change', handleChange);
     const timer = setTimeout(() => setSplash(false), 2000);
     return () => {
       sub.remove();
@@ -31,7 +37,7 @@ export default function App() {
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <StatusBar barStyle="light-content" />
-      <Home />
+      <Home ref={homeRef} />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- Refresh station data when the app returns to foreground
- Expose `onAppStateChange` on Home to bump reload tick

## Testing
- `npm test` (fails: Missing script "test")
- `npx jest` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b83bc139748328853a374630ac92f7